### PR TITLE
Added offline plugin addition.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM rabbitmq:3.6.6-management-alpine
 
 ADD rabbitmq_delayed_message_exchange-0.0.1.ez /plugins
 ADD rabbitmq_clusterer-1.0.3.ez  /plugins
-RUN rabbitmq-plugins enable rabbitmq_delayed_message_exchange
+RUN rabbitmq-plugins enable rabbitmq_delayed_message_exchange --offline
 RUN rabbitmq-plugins enable rabbitmq_clusterer --offline
 
 ENV RABBITMQ_BOOT_MODULE rabbit_clusterer


### PR DESCRIPTION
I assume that the plugin installation should include the --offline parameter. I have not tested it and the proposed change assumes that the plugin installation will fail if Rabbit is not running and the plugin is not installed.