### PR TITLE
add support for rbac roles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ RABBITMQ_MANAGEMENT_SERVICE_NAME=rabbitmq-management
 RABBITMQ_HEADLESS_SERVICE_NAME=rmq-cluster
 RABBITMQ_DOCKER_DIR=docker
 NAMESPACE?=$(shell curl -s config/$(NANIT_ENV)/$(RABBITMQ_APP_NAME)/namespace)
+RBAC?=FALSE
+SERVICE_ACCOUNT=$(shell if [ "$(RBAC)" = "TRUE" ]; then echo '\"serviceAccount\": \"$(RABBITMQ_APP_NAME)-sa\"'; fi)
 RABBITMQ_IMAGE_TAG=$(shell git log -n 1 --pretty=format:%h $(RABBITMQ_DOCKER_DIR))
 RABBITMQ_IMAGE_NAME=$(DOCKER_REPOSITORY)/$(RABBITMQ_APP_NAME):$(RABBITMQ_IMAGE_TAG)
 RABBITMQ_REPLICAS?=$(shell curl -s config/$(NANIT_ENV)/$(RABBITMQ_APP_NAME)/replicas)
@@ -37,16 +39,21 @@ define generate-rabbitmq-stateful-set
 	if [ -z "$(RABBITMQ_DEFAULT_PASS)" ]; then echo "ERROR: RABBITMQ_DEFAULT_PASS is empty!"; exit 1; fi
 	if [ -z "$(RABBITMQ_ERLANG_COOKIE)" ]; then echo "ERROR: RABBITMQ_ERLANG_COOKIE is empty!"; exit 1; fi
 	if [ -z "$(RABBITMQ_LOG_LEVEL)" ]; then echo "ERROR: RABBITMQ_LOG_LEVEL is empty!"; exit 1; fi
-	sed -e 's/{{SVC_NAME}}/$(RABBITMQ_HEADLESS_SERVICE_NAME)/g;s/{{APP_NAME}}/$(RABBITMQ_APP_NAME)/g;s,{{IMAGE_NAME}},$(RABBITMQ_IMAGE_NAME),g;s/{{REPLICAS}}/$(RABBITMQ_REPLICAS)/g;s/{{RABBITMQ_DEFAULT_USER}}/$(RABBITMQ_DEFAULT_USER)/g;s/{{RABBITMQ_DEFAULT_PASS}}/$(RABBITMQ_DEFAULT_PASS)/g;s/{{RABBITMQ_ERLANG_COOKIE}}/$(RABBITMQ_ERLANG_COOKIE)/g;s/{{RABBITMQ_LOG_LEVEL}}/$(RABBITMQ_LOG_LEVEL)/g' kube/stateful.set.yml
+	sed -e 's/{{SVC_NAME}}/$(RABBITMQ_HEADLESS_SERVICE_NAME)/g;s/{{APP_NAME}}/$(RABBITMQ_APP_NAME)/g;s,{{IMAGE_NAME}},$(RABBITMQ_IMAGE_NAME),g;s/{{REPLICAS}}/$(RABBITMQ_REPLICAS)/g;s/{{RABBITMQ_DEFAULT_USER}}/$(RABBITMQ_DEFAULT_USER)/g;s/{{RABBITMQ_DEFAULT_PASS}}/$(RABBITMQ_DEFAULT_PASS)/g;s/{{RABBITMQ_ERLANG_COOKIE}}/$(RABBITMQ_ERLANG_COOKIE)/g;s/{{RABBITMQ_LOG_LEVEL}}/$(RABBITMQ_LOG_LEVEL)/g;s/{{SERVICE_ACCOUNT}}/$(SERVICE_ACCOUNT)/g' kube/stateful.set.yml
 endef
 
 define set-ha-policy-on-rabbitmq-cluster
 	if [ "$(RABBITMQ_HA_POLICY)" != "" ]; then export RABBITMQ_HA_POLICY=$(RABBITMQ_HA_POLICY) && export NAMESPACE=$(NAMESPACE) && ./set_ha.sh ;fi
 endef
 
+define set-rbac-policy
+	sed -e 's/{{APP_NAME}}/$(RABBITMQ_APP_NAME)/g;s/{{NAMESPACE}}/$(NAMESPACE)/g' kube/rbac.role.yml
+endef
+
 deploy-rabbitmq: docker-rabbitmq
 	kubectl get ns $(NAMESPACE) || kubectl create ns $(NAMESPACE)
 	kubectl get svc -n $(NAMESPACE) $(RABBITMQ_APP_NAME) || $(call generate-rabbitmq-svc) | kubectl create -n $(NAMESPACE) -f -
+	if [ "$(RBAC)" = "TRUE" ]; then $(call set-rbac-policy) | kubectl apply -f - ; fi
 	kubectl get svc -n $(NAMESPACE) $(RABBITMQ_HEADLESS_SERVICE_NAME) || $(call generate-rabbitmq-headless-svc) | kubectl create -n $(NAMESPACE) -f -
 	if [ "$(RABBITMQ_EXPOSE_MANAGEMENT)" = "TRUE" ]; then kubectl get svc -n $(NAMESPACE) $(RABBITMQ_MANAGEMENT_SERVICE_NAME) || $(call generate-rabbitmq-management-svc) | kubectl create -n $(NAMESPACE) -f - ; fi
 	$(call generate-rabbitmq-stateful-set) | kubectl apply -n $(NAMESPACE) -f -

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It uses [rabbitmq clusterer plugin](https://github.com/rabbitmq/rabbitmq-cluster
 | NAMESPACE                    | default               | Change it if you want to create the RabbitMQ cluster in a custom Kubernetes namespace. If the namespace does not exist in the moment of deployment, it will be created for you.          
 | DOCKER_REPOSITORY            | nanit                 | Change it if you want to build and use custom docker repository          
 | SUDO                         | sudo                  | Should docker commands be prefixed with sudo. Change to "" to omit sudo. 
+| RBAC                         | FALSE                 | Should create a role/system account and role binding
 | RABBITMQ_REPLICAS            | 3                     | Number of nodes in the cluster                                           
 | RABBITMQ_DEFAULT_USER        | None                  | The default username to access the management console                    
 | RABBITMQ_DEFAULT_PASS        | None                  | The default password to access the management console                    

--- a/kube/rbac.role.yml
+++ b/kube/rbac.role.yml
@@ -1,0 +1,32 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{APP_NAME}}-cr
+rules:
+- apiGroups:
+  - apps 
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{APP_NAME}}-sa
+  namespace: {{NAMESPACE}}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{APP_NAME}}-crb
+roleRef:
+  kind: ClusterRole
+  name: {{APP_NAME}}-cr
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{APP_NAME}}-sa
+  namespace: {{NAMESPACE}}

--- a/kube/stateful.set.yml
+++ b/kube/stateful.set.yml
@@ -40,3 +40,4 @@ spec:
                 fieldPath: metadata.name
           - name: RABBITMQ_NODENAME
             value: rabbit@$(NODE_NAME).{{SVC_NAME}}
+      {{SERVICE_ACCOUNT}}


### PR DESCRIPTION
In 1.6+ the rbac is enabled by default. the command for get statefulsets : https://github.com/nanit/kubernetes-rabbitmq-cluster/blob/5eacba7b1943e28d801ae9c6dd619ec97bedfd2a/docker/set_cluster_nodes.sh#L8 

fail with Permission error.  by setting `RBAC=TRUE` a role, rolebinding and service account is created. 