### PR TITLE
allow to change KUBERNETES_APP_NAME

### DIFF
--- a/docker/set_cluster_nodes.sh
+++ b/docker/set_cluster_nodes.sh
@@ -6,7 +6,7 @@ set -u
 function join_by { local IFS="$1"; shift; echo "$*"; }
 
 STATEFUL_SETS=$(curl -f -k https://${KUBERNETES_SERVICE_HOST}/apis/apps/v1beta1/statefulsets -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)")
-RMQ_SS=$(echo $STATEFUL_SETS | jq '.items[] | select(.metadata.name == "rabbitmq")')
+RMQ_SS=$(echo $STATEFUL_SETS | jq ".items[] | select(.metadata.name == \"$APP_NAME\")")
 REPLICAS=$(echo $RMQ_SS | jq .spec.replicas)
 SERVICE_NAME=$(echo $RMQ_SS | jq .spec.serviceName | tr -d '"')
 (( REPLICAS-= 1 ))
@@ -14,10 +14,10 @@ NODES=()
 
 for i in $(seq 0 $REPLICAS)
 do
-  NODES+=("{'rabbit@rabbitmq-$i.${SERVICE_NAME}', disc}")
+  NODES+=("{'rabbit@$APP_NAME-$i.${SERVICE_NAME}', disc}")
 done
 
 JOINED=$(join_by , "${NODES[@]}")
 
 sed -i "s/@@RABBITMQ_NODES@@/$JOINED/g" /etc/rabbitmq/clusterer.config
-sed -i "s/@@RABBITMQ_GOSPEL_NODE@@/'rabbit@rabbitmq-0.$SERVICE_NAME'/g" /etc/rabbitmq/clusterer.config
+sed -i "s/@@RABBITMQ_GOSPEL_NODE@@/'rabbit@$APP_NAME-0.$SERVICE_NAME'/g" /etc/rabbitmq/clusterer.config

--- a/kube/stateful.set.yml
+++ b/kube/stateful.set.yml
@@ -44,4 +44,6 @@ spec:
                 fieldPath: metadata.name
           - name: RABBITMQ_NODENAME
             value: rabbit@$(NODE_NAME).{{SVC_NAME}}
+          - name: APP_NAME
+            value: {{APP_NAME}}
       {{SERVICE_ACCOUNT}}


### PR DESCRIPTION
This pull request fixes, so `KUBERNETES_APP_NAME` can be changed, for example to deploy multiple instances of rabbitmq