### PR TITLE
reverted k8s 1.16 changes

### DIFF
--- a/kube/stateful.set.yml
+++ b/kube/stateful.set.yml
@@ -1,13 +1,10 @@
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
   name: {{APP_NAME}}
 spec:
   serviceName: {{SVC_NAME}}
   replicas: {{REPLICAS}}
-  selector:
-    matchLabels:
-      app: {{APP_NAME}}
   template:
     metadata:
       labels:


### PR DESCRIPTION
there is a compatiblity issue with this request https://github.com/nanit/kubernetes-rabbitmq-cluster/blob/master/docker/set_cluster_nodes.sh#L8
both curl request and yaml api version have to be either apps/v1 or apps/v1beta
deploying rabbitmq is not compatible until we re-deploy with the new api version
we will have master branch with current setup and k8s.1.16 branch with both changed