### PR TITLE
add max-length policy on all queues

### DIFF
--- a/docker/set_ha.sh
+++ b/docker/set_ha.sh
@@ -9,7 +9,7 @@ while true ; do
     sleep 5
     rabbitmqctl set_policy ha-all '.*' '{{RABBITMQ_HA_POLICY}}' --apply-to queues || break
     rabbitmqctl set_policy expiry '.*' '{"expires":1800000}' --apply-to queues || break
-    rabbitmqctl set_policy max-length '.*' '{"max-length":200000, "overflow":"drop-head"}' --apply-to queues || break
+    rabbitmqctl set_policy max-length '.*' '{"max-length":200000}' --apply-to queues || break
     echo "all policies were set successfully"
     break
   fi

--- a/docker/set_ha.sh
+++ b/docker/set_ha.sh
@@ -9,7 +9,8 @@ while true ; do
     sleep 5
     rabbitmqctl set_policy ha-all '.*' '{{RABBITMQ_HA_POLICY}}' --apply-to queues || break
     rabbitmqctl set_policy expiry '.*' '{"expires":1800000}' --apply-to queues || break
-    echo "ha-all policy set successfully"
+    rabbitmqctl set_policy max-length '.*' '{"max-length":200000, "overflow":"drop-head"}' --apply-to queues || break
+    echo "all policies were set successfully"
     break
   fi
   echo "RabbitMQ still not ready..."

--- a/docker/set_ha.sh
+++ b/docker/set_ha.sh
@@ -8,8 +8,7 @@ while true ; do
     echo "RabbitMQ is ready, setting ha policy"
     sleep 5
     rabbitmqctl set_policy ha-all '.*' '{{RABBITMQ_HA_POLICY}}' --apply-to queues || break
-    rabbitmqctl set_policy expiry '.*' '{"expires":1800000}' --apply-to queues || break
-    rabbitmqctl set_operator_policy max-length '.*' '{"max-length":200000}' --apply-to queues || break
+    rabbitmqctl set_policy expiry-and-length '.*' '{"expires":1800000, "max-length":200000}' --apply-to queues || break
     echo "all policies were set successfully"
     break
   fi

--- a/docker/set_ha.sh
+++ b/docker/set_ha.sh
@@ -9,7 +9,7 @@ while true ; do
     sleep 5
     rabbitmqctl set_policy ha-all '.*' '{{RABBITMQ_HA_POLICY}}' --apply-to queues || break
     rabbitmqctl set_policy expiry '.*' '{"expires":1800000}' --apply-to queues || break
-    rabbitmqctl set_policy max-length '.*' '{"max-length":200000}' --apply-to queues || break
+    rabbitmqctl set_operator_policy max-length '.*' '{"max-length":200000}' --apply-to queues || break
     echo "all policies were set successfully"
     break
   fi


### PR DESCRIPTION
limit all queues length by using `max-length` policy:
https://www.rabbitmq.com/maxlength.html#definition

I had to combine the expiry policy since RabbitMQ limits to 1 policy per queue
https://www.rabbitmq.com/parameters.html#how-policies-work
> Each exchange or queue will have at most one policy matching (see Combining Policy Definitions below), and each policy then injects a set of key-value pairs (policy definition) on to the matching queues (exchanges).